### PR TITLE
Hide emails column on phones.

### DIFF
--- a/views/users.handlebars
+++ b/views/users.handlebars
@@ -14,7 +14,7 @@
             <table class="table table-striped table-hover">
                 <thead><tr>
                   <th>{{t 'User'}}</th>
-                  <th>{{t 'Email'}}</th>
+                  <th class="hidden-xs">{{t 'Email'}}</th>
                   <th>{{t 'Tags'}}</th>
                   <th class='euro-col'>{{t 'Balance'}}</th>
                 </tr></thead>


### PR DESCRIPTION
This column prevents seeing the 'Balance' column on small screens.
